### PR TITLE
Add hooks for post-authentication actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ module and as such does not, out of the box, provide any working functionality.
   sites configuration to allow Drupal to find the correct site configuration to
   use. If you do not have a `sites/sites.php` file (as is typical) Drupal will assume
   you are using the site defined at `sites/default`.
+- If you need custom code to execute on initial authentication or reauthentication,
+  implement the hooks `hook_saml_idp_login_completed` and `hook_saml_idp_reauthenticated`
+  in your modules.
 
 ## Copyright and License
 &copy; 2015-2018 by Brad Jones LLC. Licensed under GPL 2.

--- a/saml_idp.api.php
+++ b/saml_idp.api.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * Hook definitions for the saml_idp module.
+ */
+
+use Drupal\user\UserInterface;
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+ /**
+  * Alter user attributes passed in SAML responses.
+  *
+  * @param array $attributes
+  *   Associative array of attributes to be passed in the SAML response.
+  * @param UserInterface $user_entity
+  *   The user entity for the authenticated account
+  */
+ function hook_saml_idp_attributes_alter(&$attributes, UserInterface &$user_entity) {}
+
+ /**
+  * Perform an action when a user successfully authenticates through SAML.
+  *
+  * @param array $state
+  *   The state after the login has completed.
+  */
+ function hook_saml_idp_login_completed($state) {}
+
+ /**
+  * Perform an action when a user successfully reauthenticates through SAML.
+  *
+  * @param array $state
+  *   The state after the reauthentication has completed.
+  */
+ function hook_saml_idp_reauthenticated($state) {}
+
+/**
+ * @} End of "addtogroup hooks".
+ */


### PR DESCRIPTION
This PR creates two hooks `hook_saml_idp_login_completed` and `hook_saml_idp_reauthenticated`, so Drupal modules can perform custom operations after successful authentication or reauthentication. These are fired from new functions for `reauthenticate` and `completeAuth`, overriding those from the parent `SimpleSAML_Auth_Source` class.

(There are also some code style changes as suggested by my IDE's linter.)